### PR TITLE
New row type for UISlider

### DIFF
--- a/examples/KitchenSink/Rakefile
+++ b/examples/KitchenSink/Rakefile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
 require 'motion/project'
-require 'formotion'
+require '../../lib/formotion'
 
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.

--- a/examples/KitchenSink/app/app_delegate.rb
+++ b/examples/KitchenSink/app/app_delegate.rb
@@ -85,6 +85,12 @@ class AppDelegate
           key: :date_short,
           type: :date,
           format: :short
+        }, {
+          title: "Slider",
+          key: :slider,
+          type: :slider,
+          range: (1..100),
+          value: 25
         }]
       }, {
         title: "Select One",

--- a/lib/formotion/row/row.rb
+++ b/lib/formotion/row/row.rb
@@ -40,6 +40,10 @@ module Formotion
       # EX 200
       # DEFAULT is nil, which is used as the tableView.rowHeight
       :rowHeight,
+      # range used for slider min and max value
+      # EX (1..100)
+      # DEFAULT is (1..10)
+      :range,
     ]
     PROPERTIES.each {|prop|
       attr_accessor prop

--- a/lib/formotion/row_type/slider_row.rb
+++ b/lib/formotion/row_type/slider_row.rb
@@ -1,0 +1,42 @@
+module Formotion
+  module RowType
+    class SliderRow < Base
+
+      SLIDER_VIEW_TAG = 1200
+
+      def build_cell(cell)
+        cell.selectionStyle = UITableViewCellSelectionStyleNone
+        slideView = UISlider.alloc.initWithFrame(CGRectZero)
+        cell.accessoryView = slideView
+        row.range ||= (1..10)
+        slideView.minimumValue = row.range.first
+        slideView.maximumValue = row.range.last
+        slideView.tag = SLIDER_VIEW_TAG
+        slideView.setValue(row.value, animated:true) if row.value
+
+        slideView.when(UIControlEventValueChanged) do
+          row.value = slideView.value
+        end
+
+        cell.swizzle(:layoutSubviews) do
+          def layoutSubviews
+            old_layoutSubviews
+
+            # viewWithTag is terrible, but I think it's ok to use here...
+            formotion_field = self.viewWithTag(SLIDER_VIEW_TAG)
+            formotion_field.sizeToFit
+
+            field_frame = formotion_field.frame
+            field_frame.origin.y = 10
+            field_frame.origin.x = self.textLabel.frame.origin.x + self.textLabel.frame.size.width + 20
+            field_frame.size.width  = self.frame.size.width - field_frame.origin.x - 20
+            field_frame.size.height = self.frame.size.height - 20
+            formotion_field.frame = field_frame
+          end
+        end
+        nil
+      end
+
+    end
+  end
+end

--- a/spec/row_type/slider_spec.rb
+++ b/spec/row_type/slider_spec.rb
@@ -1,0 +1,47 @@
+describe "Slider Row" do
+  before do
+    row_settings = {
+      title: "Slider",
+      key: :slider,
+      type: :slider,
+      range: (1..100)
+    }
+    @row = Formotion::Row.new(row_settings)
+    @row.reuse_identifier = 'test'
+  end
+
+  it "should initialize with correct settings" do
+    @row.object.class.should == Formotion::RowType::SliderRow
+  end
+
+  it "should build cell with slider" do
+    cell = @row.make_cell
+    cell.accessoryView.class.should == UISlider
+  end
+
+  # Value
+  it "should set custom value" do
+    @row.value = 50
+    cell = @row.make_cell
+
+    cell.accessoryView.value.should == 50
+    @row.value.should == 50
+  end
+
+  # Range
+  it "should use default range" do
+    @row.range = nil
+    cell = @row.make_cell
+
+    cell.accessoryView.minimumValue.should == 1
+    cell.accessoryView.maximumValue.should == 10
+  end
+
+  it "should use custom range values" do
+    @row.range = (50..100)
+    cell = @row.make_cell
+
+    cell.accessoryView.minimumValue.should == 50
+    cell.accessoryView.maximumValue.should == 100
+  end
+end


### PR DESCRIPTION
Builds a new row type for an UISlider

``` ruby
{
  title: "Slider",
  key: :slider,
  type: :slider,
  range: (1..100),
  value: 25
}
```

![Preview](https://dl.dropbox.com/u/1098463/Screenshots/Screen%20Shot%202012-07-05%20at%2011.20.41%20.png)
