### PR TITLE
New row type for UISegmentedControl

### DIFF
--- a/examples/KitchenSink/app/app_delegate.rb
+++ b/examples/KitchenSink/app/app_delegate.rb
@@ -17,6 +17,11 @@ class AppDelegate
           auto_correction: :no,
           auto_capitalization: :none
         }, {
+          title: "Gender",
+          key: :gender,
+          type: :control,
+          items: ['Female', 'Male']
+        }, {
           title: "Password",
           key: :password,
           placeholder: "required",

--- a/lib/formotion/row/row.rb
+++ b/lib/formotion/row/row.rb
@@ -40,6 +40,10 @@ module Formotion
       # EX 200
       # DEFAULT is nil, which is used as the tableView.rowHeight
       :rowHeight,
+      # Array used for control row items
+      # EX ['free', 'pro']
+      # DEFAULT is []
+      :items,
     ]
     PROPERTIES.each {|prop|
       attr_accessor prop

--- a/lib/formotion/row_type/control_row.rb
+++ b/lib/formotion/row_type/control_row.rb
@@ -1,0 +1,24 @@
+module Formotion
+  module RowType
+    class ControlRow < Base
+
+      SLIDER_VIEW_TAG = 1200
+
+      def build_cell(cell)
+        cell.selectionStyle = UITableViewCellSelectionStyleNone
+        slideView = UISegmentedControl.alloc.initWithItems(row.items || [])
+        slideView.selectedSegmentIndex = row.items.index(row.value) if row.value
+        slideView.segmentedControlStyle = UISegmentedControlStyleBar
+        cell.accessoryView = slideView
+
+        slideView.when(UIControlEventValueChanged) do
+          row.value = row.items[slideView.selectedSegmentIndex]
+        end
+
+        nil
+      end
+
+
+    end
+  end
+end

--- a/spec/row_type/control_spec.rb
+++ b/spec/row_type/control_spec.rb
@@ -1,0 +1,37 @@
+describe "Slider Row" do
+  before do
+    row_settings = {
+      title: "Control",
+      key: :control,
+      type: :control,
+      items: ['First', 'Second']
+    }
+    @row = Formotion::Row.new(row_settings)
+    @row.reuse_identifier = 'test'
+  end
+
+  it "should initialize with correct settings" do
+    @row.object.class.should == Formotion::RowType::ControlRow
+  end
+
+  it "should build cell with segmented control" do
+    cell = @row.make_cell
+    cell.accessoryView.class.should == UISegmentedControl
+  end
+
+  # Value
+  it "should select default value" do
+    cell = @row.make_cell
+
+    cell.accessoryView.selectedSegmentIndex.should == -1
+    @row.value.should == nil
+  end
+
+  it "should select custom value" do
+    @row.value = 'Second'
+    cell = @row.make_cell
+
+    cell.accessoryView.selectedSegmentIndex.should == 1
+    @row.value.should == 'Second'
+  end
+end


### PR DESCRIPTION
Builds a new row type for an UISegmentedControl

![Preview](https://dl.dropbox.com/u/1098463/Screenshots/Screen%20Shot%202012-07-05%20at%2014.00.31%20.png)

``` ruby
{
  title: "Gender",
  key: :gender,
  type: :control,
  items: ['Female', 'Male']
}
```
