### PR TITLE
reuse identifier...

### DIFF
--- a/lib/formotion/row/row.rb
+++ b/lib/formotion/row/row.rb
@@ -117,7 +117,7 @@ module Formotion
     end
 
     def reuse_identifier
-      @reuse_identifier || "SECTION_#{self.section.index}_ROW_#{self.index}"
+      @reuse_identifier || "Formotion_#{self.object_id}"
     end
 
     def next_row


### PR DESCRIPTION
In my app, I am changing the form at run time, and the reuse identifier was giving me headaches because it was based only on section and row.

When I insert a row into the list, it reuses the wrong cell!  So instead, I am having it reuse based on `object_id`.  Doesn't address the fact that cells that _are_ the same are not being reused, but I don't think these forms can be expected to have hundreds of rows anyway, so the performance gain might not be that much... I'll leave it up to you, anyway :-)
