### PR TITLE
Fix `EXC_BAD_ACCESS` crash in UITextView.

### DIFF
--- a/lib/formotion/patch/ui_text_view_placeholder.rb
+++ b/lib/formotion/patch/ui_text_view_placeholder.rb
@@ -19,7 +19,13 @@ class UITextView
   def setup
     @foreground_observer = NSNotificationCenter.defaultCenter.observe UITextViewTextDidChangeNotification do |notification|
       updateShouldDrawPlaceholder
-    end  
+    end
+  end
+
+  alias_method :old_dealloc, :dealloc
+  def dealloc
+    NSNotificationCenter.defaultCenter.unobserve @foreground_observer
+    old_dealloc
   end
 
   alias_method :old_drawRect, :drawRect


### PR DESCRIPTION
Need to unobserve the  `UITextViewTextDidChangeNotification`  when a `UITextView` object is dealloced, or will cause a `EXC_BAD_ACCESS` crash when another object send that notification agian.
