### PR TITLE
Intelligently pick the top most view controller to present UIImagePicker...

### DIFF
--- a/lib/formotion/row_type/image_row.rb
+++ b/lib/formotion/row_type/image_row.rb
@@ -79,7 +79,7 @@ module Formotion
 
         if source
           @camera = BW::Device.camera.send((source == :camera) ? :rear : :any)
-          @camera.picture(source_type: source, media_types: [:image]) do |result|
+          @camera.picture({source_type: source, media_types: [:image]}, App.delegate.window.rootViewController.presentedViewController) do |result|
             if result[:original_image]
               row.value = result[:original_image]
             end


### PR DESCRIPTION
Currently, if you have an `:image` row inside a form that is shown modally, the `UIActionSheet` is displayed, but the `UIImagePickerController` can't do it's thing b/c it's being asked to be presented from a view controller that's not on the screen.

I was able to reproduce this with a `UITabBarController` presenting a `UINavigationController` with a `UITableViewController`...showing a plain controller modally.

The `UIImagePickerController` yells b/c the `UITabBarController` isn't shown on the screen.

`BW::Device.camera.any.picture()` accepts a view controller argument, or nil.  This pull request will pass in the top most present view controller (if it exists), or nil if it doesn't, in which both cases we have the desired effect of getting the `UIImagePickerController` to present itself.
