### PR TITLE
modified form_delegate.rb def controller=(controller) to replace non-exi...

### DIFF
--- a/lib/formotion/form/form_delegate.rb
+++ b/lib/formotion/form/form_delegate.rb
@@ -18,7 +18,7 @@ module Formotion
     def controller=(controller)
       @controller = controller
       @controller.title = self.title
-      self.table = controller.respond_to?(:table) ? controller.table : controller.tableView
+      self.table = @controller.tableView
     end
 
     def table=(table_view)


### PR DESCRIPTION
This is my first attempt at forking a repo to make a (quite small) contribution to a project. Basically, this a small fix that corrects an in-line if statement that is messaging a non-existent getter - the code was working just not the way it was intended to (I think :-) )

Changed "def controller=(controller)" method.

Modified controller.respond_to msg - replaced two non-existent getter msgs "table_view"
with existing "table" getter msgs.

Perhaps a better change I could have made would have been to change the getter and setter method names to table_view, however I didn't want to make to many changes until I gain more experience and will leave it to owner to decide the best implementation.
