### PR TITLE
CurrencyRow type added

### DIFF
--- a/LIST_OF_ROW_TYPES.md
+++ b/LIST_OF_ROW_TYPES.md
@@ -4,6 +4,7 @@
 [Email](#email)<br/>
 [Phone](#phone)<br/>
 [Number](#number)<br/>
+[Currency](#currency)<br/>
 [Date](#date)
 
 **Other**<br/>
@@ -129,6 +130,21 @@ The `PhoneRow` is a string input row for a phone number and opens a `UIKeyboardT
 ```
 
 The `NumberRow` is a string input row for a number and opens a `UIKeyboardTypeDecimalPad` keyboard when editing.
+
+
+### <a name="currency"></a> Currency Row
+![Currency row](https://github.com/clayallsopp/formotion/wiki/row-types/currency_row.png)
+
+```ruby
+{
+  title: "Amount",
+  key: :amount,
+  placeholder: "0.00",
+  type: :currency
+}
+```
+
+The `CurrentyRow` is a string input row with a number keyboard that restricts users to entering valid currency without tapping the decimal key on the keyboard.
 
 
 ### <a name="date"></a> Date row

--- a/lib/formotion.rb
+++ b/lib/formotion.rb
@@ -17,6 +17,11 @@ BW.require File.expand_path('../formotion/**/*.rb', __FILE__) do
   ['date_row', 'email_row', 'number_row', 'phone_row'].each {|file|
     file("lib/formotion/row_type/#{file}.rb").depends_on 'lib/formotion/row_type/string_row.rb'
   }
+
+  ['currency_row'].each {|file|
+    file("lib/formotion/row_type/#{file}.rb").depends_on 'lib/formotion/row_type/number_row.rb'
+  }
+  
   ['submit_row', 'back_row'].each {|file|
     file("lib/formotion/row_type/#{file}.rb").depends_on 'lib/formotion/row_type/button.rb'
   }

--- a/lib/formotion/form/form.rb
+++ b/lib/formotion/form/form.rb
@@ -172,9 +172,9 @@ module Formotion
               # If this row is part of a template
               # use the parent's key
               kv[row.template_parent.key] ||= []
-              kv[row.template_parent.key] << row.value
+              kv[row.template_parent.key] << row.value_for_save_hash
             else
-              kv[row.key] ||= row.value
+              kv[row.key] ||= row.value_for_save_hash
             end
           }
         end

--- a/lib/formotion/row/row.rb
+++ b/lib/formotion/row/row.rb
@@ -145,6 +145,14 @@ module Formotion
     #########################
     # pseudo-properties
 
+    def value_for_save_hash
+      if self.object.respond_to? :value_for_save_hash
+        self.object.value_for_save_hash
+      else
+        self.value
+      end
+    end
+
     def index_path
       NSIndexPath.indexPathForRow(self.index, inSection:self.section.index)
     end

--- a/lib/formotion/row_type/currency_row.rb
+++ b/lib/formotion/row_type/currency_row.rb
@@ -1,0 +1,64 @@
+module Formotion
+  module RowType
+    class CurrencyRow < NumberRow
+
+      def add_callbacks(field)
+        super
+
+        field.should_change? do |text_field, range, replacements|
+
+          original_txt = text_field.text
+          edited_txt = original_txt.stringByReplacingCharactersInRange(range, withString:replacements)
+          entered_digits = edited_txt.gsub %r{\D+}, ''
+
+          if entered_digits.length >= 9
+            
+            text_field.text = original_txt
+
+          else 
+
+            if entered_digits.empty?
+              decimal_num = 0.0
+            else
+              decimal_num = entered_digits.to_i * (10 ** currency_scale)
+              decimal_num = decimal_num.to_f
+            end
+
+            text_field.text = number_formatter.stringFromNumber decimal_num
+
+          end
+
+          false
+        end
+
+      end
+
+
+      def row_value
+        number_formatter.stringFromNumber super.to_f
+      end
+
+
+      def value_for_save_hash
+        number_formatter.numberFromString(row.text_field.text) || 0.0
+      end
+
+
+      private
+
+      def number_formatter
+        @number_formatter ||= begin
+          formatter = NSNumberFormatter.alloc.init
+          formatter.numberStyle = NSNumberFormatterCurrencyStyle
+          formatter.locale = NSLocale.currentLocale
+          formatter
+        end
+      end
+
+      def currency_scale
+        @currency_scale ||= number_formatter.maximumFractionDigits * -1
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Subclass of `NumberRow`, restricts user to entering valid currency with 2 trailing decimals without tapping the decimal key, like entering money on an ATM keypad.
