### PR TITLE
UITextField: remove custom canPerformAction(action, withSender:sender)

### DIFF
--- a/lib/formotion/patch/ui_text_field.rb
+++ b/lib/formotion/patch/ui_text_field.rb
@@ -15,12 +15,6 @@
 # end
 
 class UITextField
-  attr_accessor :menu_options_enabled
-
-  def canPerformAction(action, withSender:sender)
-    self.menu_options_enabled
-  end
-
   # block takes argument textField; should return true/false
   def should_begin?(&block)
     add_delegate_method do


### PR DESCRIPTION
Hi,

I ran into troubles with `UITextField` regarding the double-tap(?) menu (select,select all, paste) which did not appear even when `editable: true` is set for the row.

After checking the formotion source I think `canPerformAction(action, withSender:sender)`is the reason: Either it is true, then all available menu options (including "take a photo"…) will be shown, but by default no menu is shown. This means no copy/paste is currently possible by default.

Removing this method makes UITextField using its defaults which are sane (e.g. allow a user to select/copy or paste content again).

<img src="http://i.imgur.com/qhLkd2p.png">

Maybe there is a better idea to fix this problem. I have no idea, sorry :(
