### PR TITLE
Travis CI Support for Formotion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: objective-c
+before_install:
+  - source /Users/travis/.bash_profile
+  - rvm use 1.9.3
+install: bundle install
+script: bundle exec rake spec


### PR DESCRIPTION
Now that travis-ci.org allows to add RubyMotion and iOS projects (YAY for that) we should add it too.

I've tested it and [it works as expected](https://travis-ci.org/mordaroso/formotion)

Steps to add formotion to travis:
1. Login to travis-ci.org
2. Goto [profile page](https://travis-ci.org/profile) and activate formotion
3. Accept pull request
4. Watch the project compile and run the specs
5. [Add a status image to the README](http://about.travis-ci.org/docs/user/status-images/#Adding-Status-Images-to-README-Files)
6. Profit!
