### PR TITLE
Created a display_input_accessory_view property for StringRow.

### DIFF
--- a/lib/formotion/row/row.rb
+++ b/lib/formotion/row/row.rb
@@ -89,10 +89,9 @@ module Formotion
       # be set. That allows picking by every 15 minutes, etc.
       :minute_interval,
       # Display an inputAccessoryView when editing a StringRow.
-      # Default input accessory view is nav bar with a "Done" button.
-      # It can be changed by overriding the input_accessory_view method.
-      # DEFAULT is false
-      :display_input_accessory_view
+      # OPTIONS: :done (a black translucent toolbar with a right-aligned "Done" button)
+      # DEFAULT is nil
+      :input_accessory
     ]
     PROPERTIES.each {|prop|
       attr_accessor prop

--- a/lib/formotion/row_type/string_row.rb
+++ b/lib/formotion/row_type/string_row.rb
@@ -42,7 +42,7 @@ module Formotion
         field.autocorrectionType = row.auto_correction if row.auto_correction
         field.clearButtonMode = row.clear_button || UITextFieldViewModeWhileEditing
         field.enabled = row.editable?
-        field.inputAccessoryView = input_accessory_view if row.display_input_accessory_view
+        field.inputAccessoryView = input_accessory_view(row.input_accessory) if row.input_accessory
 
         add_callbacks(field)
 
@@ -147,20 +147,34 @@ module Formotion
         self.row.text_field.text = row_value
       end
 
-      # Creates the default inputAccessoryView to show
-      # if display_input_accessory_view property is set.
-      def input_accessory_view
-        @nav_bar ||= begin
-          nav_bar = UINavigationBar.alloc.initWithFrame([[0, 0], [320, 44]])
-          nav_bar.autoresizingMask = UIViewAutoresizingFlexibleWidth
-          item = UINavigationItem.new
-          item.rightBarButtonItem = UIBarButtonItem.alloc.initWithBarButtonSystemItem(
-              UIBarButtonSystemItemDone,
-              target: self,
-              action: :done_editing)
-          nav_bar.items = [item]
+      # Creates the inputAccessoryView to show
+      # if input_accessory property is set on row.
+      # :done is currently the only supported option.
+      def input_accessory_view(input_accessory)
+        case input_accessory
+        when :done
+          @input_accessory ||= begin
+            tool_bar = UIToolbar.alloc.initWithFrame([[0, 0], [0, 44]])
+            tool_bar.autoresizingMask = UIViewAutoresizingFlexibleWidth
+            tool_bar.barStyle = UIBarStyleBlack
+            tool_bar.translucent = true
 
-          nav_bar
+            left_space = UIBarButtonItem.alloc.initWithBarButtonSystemItem(
+                UIBarButtonSystemItemFlexibleSpace,
+                target: nil,
+                action: nil)
+
+            done_button = UIBarButtonItem.alloc.initWithBarButtonSystemItem(
+                UIBarButtonSystemItemDone,
+                target: self,
+                action: :done_editing)
+
+            tool_bar.items = [left_space, done_button]
+
+            tool_bar
+          end
+        else
+          nil
         end
       end
 


### PR DESCRIPTION
Default implementation displays a "Done" button to close the keyboard or input views.
# Background

Thanks so much for making Formotion!  It's such a pleasure to work with.

I've been creating forms with a lot of different kinds of text fields (dates, pickers, numbers, etc).  I ran into a slight usability issue in that I can't seem to find a way to close the inputView, example below:
![image](https://f.cloud.github.com/assets/157972/359892/ca00370e-a174-11e2-8f14-320404043e3a.png)

So I added an option to display an input accessory view with a "Done" button to close the input view, e.g:
![image](https://f.cloud.github.com/assets/157972/359923/f2dc783a-a175-11e2-8f6a-74f8529fcb9e.png)

I thought others might find it helpful as well.
# Usage

Add a _display_input_accessory_view_ property set to _true_, e.g:

``` json
{
  title: "Date of Birth",
  key: :dob,
  type: :date,
  display_input_accessory_view: true
}
```
