### PR TITLE
Add tiny helper to return row by key

### DIFF
--- a/LIST_OF_ROW_TYPES.md
+++ b/LIST_OF_ROW_TYPES.md
@@ -414,10 +414,11 @@ Use a `:display_key` to show the value of the subform in the row:
 {
   title: "Any Button",
   type: :button,
+  key: :some_button
 }
 
 # later...
-form.sections[0].rows[0].on_tap do |row|
+form.row(:some_button).on_tap do |row|
   # do something when tapped
 end
 ```

--- a/lib/formotion/form/form.rb
+++ b/lib/formotion/form/form.rb
@@ -96,6 +96,13 @@ module Formotion
       self.sections[index_path.section].rows[index_path.row]
     end
 
+    def row(key)
+      each_row do |row|
+        return row if row.key == key
+      end
+      nil
+    end
+
     #########################
     #  callbacks
 

--- a/spec/form_spec.rb
+++ b/spec/form_spec.rb
@@ -52,6 +52,32 @@ describe "Forms" do
     row.title.should == "Label"
     row.subtitle.should == "Placeholder"
   end
+  
+  it "should return row by key" do
+    @form = Formotion::Form.new(sections: [{
+      rows: [{
+        key: :email,
+        type: :email,
+        editable: true,
+        title: 'Email'
+      }]
+    }])
+
+    expected = @form.sections[0].rows[0]
+    @form.row(:email).should == expected
+  end
+  
+  it "should return nil for row by key if key does not exist" do
+    @form = Formotion::Form.new(sections: [{
+      rows: [{
+        key: :email,
+        type: :email,
+        editable: true,
+        title: 'Email'
+      }]
+    }])
+    @form.row(:foobar).should.be.nil
+  end
 
   it "render works correctly" do
     @form = Formotion::Form.new(sections: [{


### PR DESCRIPTION
This commit allows to retrieve the row object by its key, like this:

```
@form = Formotion::Form.new(…) # some section has a row :edit_button
@form.row(:edit_button).on_tap do
  puts "hello"
end
```
