### PR TITLE
Disable editing of picker row fields. fixes #102

### DIFF
--- a/lib/formotion/row_type/date_row.rb
+++ b/lib/formotion/row_type/date_row.rb
@@ -3,17 +3,7 @@ motion_require 'string_row'
 module Formotion
   module RowType
     class DateRow < StringRow
-
-      def build_cell(cell)
-        field = super(cell)
-        field.clearButtonMode = UITextFieldViewModeNever
-        field.swizzle(:caretRectForPosition) do
-          def caretRectForPosition(position)
-            CGRectZero
-          end
-        end
-        field
-      end
+      include RowType::MultiChoiceRow
 
       # overwrite Character on_change method
       def on_change(text_field)
@@ -50,13 +40,6 @@ module Formotion
       def after_build(cell)
         self.row.text_field.inputView = self.picker
         update
-      end
-
-      def add_callbacks(field)
-        super
-        field.should_change? do |text_field|
-          false
-        end
       end
 
       def picker

--- a/lib/formotion/row_type/multi_choice_row.rb
+++ b/lib/formotion/row_type/multi_choice_row.rb
@@ -1,0 +1,25 @@
+module Formotion
+  module RowType
+    module MultiChoiceRow
+
+    def build_cell(cell)
+      field = super(cell)
+      field.clearButtonMode = UITextFieldViewModeNever
+      field.swizzle(:caretRectForPosition) do
+        def caretRectForPosition(position)
+          CGRectZero
+        end
+      end
+      field
+    end
+
+    def add_callbacks(field)
+      super
+      field.should_change? do |text_field|
+        false
+      end
+    end
+
+    end
+  end
+end

--- a/lib/formotion/row_type/picker_row.rb
+++ b/lib/formotion/row_type/picker_row.rb
@@ -5,28 +5,11 @@ module Formotion
   module RowType
     class PickerRow < StringRow
       include RowType::ItemsMapper
-
-      def build_cell(cell)
-        field = super(cell)
-        field.clearButtonMode = UITextFieldViewModeNever
-        field.swizzle(:caretRectForPosition) do
-          def caretRectForPosition(position)
-            CGRectZero
-          end
-        end
-        field
-      end
+      include RowType::MultiChoiceRow
 
       def after_build(cell)
         self.row.text_field.inputView = self.picker
         self.row.text_field.text = name_for_value(row.value).to_s
-      end
-
-      def add_callbacks(field)
-        super
-        field.should_change? do |text_field|
-          false
-        end
       end
 
       def picker

--- a/spec/functional/date_row_spec.rb
+++ b/spec/functional/date_row_spec.rb
@@ -60,4 +60,10 @@ describe "FormController/DateRow" do
       end
     end
   end
+
+  it "doesn't have a clear button" do
+    tap("Date")
+    date_row.text_field.subviews.map(&:class).should.not.include UIButton
+  end
+
 end

--- a/spec/functional/picker_row_spec.rb
+++ b/spec/functional/picker_row_spec.rb
@@ -58,4 +58,9 @@ describe "FormController/PickerRow" do
       end
     end
   end
+
+  it "doesn't have a clear button" do
+    tap("Picker")
+    picker_row.text_field.subviews.map(&:class).should.not.include UIButton
+  end
 end


### PR DESCRIPTION
Modifies PickerRow and DateRow to:
- hide the caret while the text field is being edited
- not show the clear button
- not allow any text changes coming from a keyboard

Thoughts: looking at this patch, it's probably clear that
- DateRow should inherit from PickerRow
- PickerRow should not inherit from StringRow, and should not have a text field, but rather be a direct subclass of Formotion::RowType::Base and have a UILabel.
