### PR TITLE
Formotion::RowType::SubformRow#build_cell should return nil

### DIFF
--- a/lib/formotion/row_type/subform_row.rb
+++ b/lib/formotion/row_type/subform_row.rb
@@ -28,6 +28,7 @@ module Formotion
         end
 
         display_key_label.highlightedTextColor = cell.textLabel.highlightedTextColor
+        nil
       end
 
       def update_cell(cell)


### PR DESCRIPTION
It returned a instance of UIColor instead of nil that caused an NoMethodError at string_row.rb:109
