### PR TITLE
Use WeakRef to prevent crash on RM 2.5/2.6

### DIFF
--- a/lib/formotion/section/section.rb
+++ b/lib/formotion/section/section.rb
@@ -45,7 +45,7 @@ module Formotion
       if hash.class == Hash
         row = Formotion::Row.new(hash)
       end
-      row.section = self
+      row.section = WeakRef.new(self)
       row.index = self.rows.count
       row
     end


### PR DESCRIPTION
Workaround for #131.

Not sure if this is something that should be fixed by RubyMotion, but it does prevent the crash.

@lrz should this be merged or should we just wait for a fix in http://hipbyte.myjetbrains.com/youtrack/issue/RM-236?
