### PR TITLE
Adjusting persist to only require the property `persist_as` to be set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,20 +181,20 @@ end
 
 ### Persistence
 
-You can easily synchronize a `Form`'s state to disk using the `persist_as` key in conjunction with the `persist` method. When your user edits the form, any changes will be immediately saved. For example:
+You can easily synchronize a `Form`'s state to disk using the `persist_as` key in form properties. When your user edits the form, any changes will be immediately saved. For example:
 
 ```ruby
-@form = Formotion::Form.persist({
+@form = Formotion::Form.new({
   persist_as: :settings,
   sections: ...
 })
 ```
 
-This will load the form if it exists, or create it if necessary. If you use `Formotion::Form.new`, then the form will not be loaded and any changes you make will override existing saved forms.
+This will load the form if it exists, or create it if necessary. If you use remove the `persist_as` key, then the form will not be loaded and any changes you make will override existing saved forms.
 
 Your form values and state are automatically persisted across application loads, no save buttons needed.
 
-To reset the form, `persist` it and call `reset`, which restores it to the original state.
+To reset the form, call `reset`, which restores it to the original state.
 
 View the [Persistence Example](./examples/Persistence) to see it in action.
 

--- a/examples/Persistence/app/controller.rb
+++ b/examples/Persistence/app/controller.rb
@@ -47,7 +47,7 @@ class AccountSettingsController < Formotion::FormController
   end
 
   def initController
-    f = Formotion::Form.persist(SETTINGS_HASH)
+    f = Formotion::Form.new(SETTINGS_HASH)
     initWithForm(f)
   end
 end

--- a/lib/formotion/form/form.rb
+++ b/lib/formotion/form/form.rb
@@ -24,8 +24,6 @@ module Formotion
 
     def self.persist(params = {})
       form = new(params)
-      form.open
-      form.init_observer_for_save
       form
     end
 
@@ -37,6 +35,15 @@ module Formotion
       sections && sections.each_with_index {|section_hash, index|
         section = create_section(section_hash.merge({index: index}))
       }
+
+      initialize_persist unless self.persist_as.nil?
+
+    end
+
+    def initialize_persist
+      self.open
+      self.init_observer_for_save
+      self
     end
 
     # Use this as a DSL for building forms


### PR DESCRIPTION
This makes it easier to use persist, and somewhat deprecates the old `Formotion::Form.persist`
