### PR TITLE
ios7 fix with uitextview's font

### DIFF
--- a/lib/formotion/patch/ui_text_view_placeholder.rb
+++ b/lib/formotion/patch/ui_text_view_placeholder.rb
@@ -34,6 +34,7 @@ class UITextView
 
     if (@shouldDrawPlaceholder)
         self.placeholder_color.set
+        self.font ||= UIFont.systemFontOfSize(17) # ios7 seems to have a bug where font of uitextview isn't set by default
         self.placeholder.drawInRect(placeholder_rect, withFont:self.font)
     end
   end


### PR DESCRIPTION
ios7 uitextview does not seem to set a default font.
