### PR TITLE
Allocate form controller using self.class.alloc

### DIFF
--- a/lib/formotion/controller/form_controller.rb
+++ b/lib/formotion/controller/form_controller.rb
@@ -60,7 +60,7 @@ module Formotion
 
     # Subview Methods
     def push_subform(form)
-      @subform_controller = Formotion::FormController.alloc.initWithForm(form)
+      @subform_controller = self.class.alloc.initWithForm(form)
 
       if self.navigationController
         self.navigationController.pushViewController(@subform_controller, animated: true)


### PR DESCRIPTION
This PR will ensure that subclasses of Formotion::FormController are allocated with the subclass instead of base controller Formotion::FormController.
