### PR TITLE
Remove use of &/to_proc syntactic sugar since it causes RubyMotion to leak

### DIFF
--- a/Formotion.gemspec
+++ b/Formotion.gemspec
@@ -16,6 +16,5 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency "bubble-wrap", ">= 1.4.0"
-  s.add_dependency "motion-require", ">= 0.1.0"
   s.add_development_dependency 'rake'
 end

--- a/lib/formotion.rb
+++ b/lib/formotion.rb
@@ -3,13 +3,14 @@ require 'bubble-wrap/core'
 require 'bubble-wrap/font'
 require 'bubble-wrap/camera'
 
-require 'motion-require'
-
-Motion::Require.all(Dir.glob(File.expand_path('../formotion/**/*.rb', __FILE__)))
-
 Motion::Project::App.setup do |app|
   app.frameworks<<'CoreLocation' unless app.frameworks.include?('CoreLocation')
   app.frameworks<<'MapKit' unless app.frameworks.include?('MapKit')
   
   app.resources_dirs << File.join(File.dirname(__FILE__), '../resources')
+
+  Dir.glob(File.join(File.dirname(__FILE__), 'formotion/**/*.rb')).each do |file|
+    app.files.unshift(file)
+  end
+
 end

--- a/lib/formotion/base.rb
+++ b/lib/formotion/base.rb
@@ -1,4 +1,4 @@
-motion_require 'row_type/base'
+
 
 module Formotion
   class Base

--- a/lib/formotion/controller/form_controller.rb
+++ b/lib/formotion/controller/form_controller.rb
@@ -1,4 +1,4 @@
-motion_require '../patch/ui_text_field'
+
 
 #################
 #

--- a/lib/formotion/form/form.rb
+++ b/lib/formotion/form/form.rb
@@ -1,4 +1,4 @@
-motion_require "../base"
+
 
 module Formotion
   class Form < Formotion::Base

--- a/lib/formotion/form/form_delegate.rb
+++ b/lib/formotion/form/form_delegate.rb
@@ -1,4 +1,4 @@
-motion_require "../base"
+
 
 module Formotion
   class Form < Formotion::Base

--- a/lib/formotion/row/row.rb
+++ b/lib/formotion/row/row.rb
@@ -1,4 +1,4 @@
-motion_require "../base"
+
 
 module Formotion
   class Row < Formotion::Base

--- a/lib/formotion/row_type/activity_view_row.rb
+++ b/lib/formotion/row_type/activity_view_row.rb
@@ -1,4 +1,4 @@
-motion_require 'object_row'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/back_row.rb
+++ b/lib/formotion/row_type/back_row.rb
@@ -1,4 +1,4 @@
-motion_require 'button'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/button.rb
+++ b/lib/formotion/row_type/button.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/check_row.rb
+++ b/lib/formotion/row_type/check_row.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/currency_row.rb
+++ b/lib/formotion/row_type/currency_row.rb
@@ -1,4 +1,4 @@
-motion_require 'number_row'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/date_row.rb
+++ b/lib/formotion/row_type/date_row.rb
@@ -1,5 +1,5 @@
-motion_require 'string_row'
-motion_require 'multi_choice_row'
+
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/edit_row.rb
+++ b/lib/formotion/row_type/edit_row.rb
@@ -1,4 +1,4 @@
-motion_require 'button'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/email_row.rb
+++ b/lib/formotion/row_type/email_row.rb
@@ -1,4 +1,4 @@
-motion_require 'string_row'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/image_row.rb
+++ b/lib/formotion/row_type/image_row.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/map_row.rb
+++ b/lib/formotion/row_type/map_row.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/number_row.rb
+++ b/lib/formotion/row_type/number_row.rb
@@ -1,4 +1,4 @@
-motion_require 'string_row'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/object_row.rb
+++ b/lib/formotion/row_type/object_row.rb
@@ -1,4 +1,4 @@
-motion_require 'string_row'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/options_row.rb
+++ b/lib/formotion/row_type/options_row.rb
@@ -1,5 +1,5 @@
-motion_require 'base'
-motion_require 'items_mapper'
+
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/paged_image_row.rb
+++ b/lib/formotion/row_type/paged_image_row.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 # ideas taken from:
 # http://www.raywenderlich.com/10518/how-to-use-uiscrollview-to-scroll-and-zoom-content

--- a/lib/formotion/row_type/phone_row.rb
+++ b/lib/formotion/row_type/phone_row.rb
@@ -1,4 +1,4 @@
-motion_require 'string_row'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/picker_row.rb
+++ b/lib/formotion/row_type/picker_row.rb
@@ -1,6 +1,6 @@
 # currently supports only one component
-motion_require 'string_row'
-motion_require 'multi_choice_row'
+
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/slider_row.rb
+++ b/lib/formotion/row_type/slider_row.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/static_row.rb
+++ b/lib/formotion/row_type/static_row.rb
@@ -1,4 +1,4 @@
-motion_require 'string_row'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/string_row.rb
+++ b/lib/formotion/row_type/string_row.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/subform_row.rb
+++ b/lib/formotion/row_type/subform_row.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/submit_row.rb
+++ b/lib/formotion/row_type/submit_row.rb
@@ -1,4 +1,4 @@
-motion_require 'button'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/switch_row.rb
+++ b/lib/formotion/row_type/switch_row.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/tags_row.rb
+++ b/lib/formotion/row_type/tags_row.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 # ideas and images taken from:
 # https://github.com/davbeck/TURecipientBar

--- a/lib/formotion/row_type/template_row.rb
+++ b/lib/formotion/row_type/template_row.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 # Define template row:
 # {

--- a/lib/formotion/row_type/text_row.rb
+++ b/lib/formotion/row_type/text_row.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/web_link_row.rb
+++ b/lib/formotion/row_type/web_link_row.rb
@@ -1,4 +1,4 @@
-motion_require 'object_row'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/web_view_row.rb
+++ b/lib/formotion/row_type/web_view_row.rb
@@ -1,4 +1,4 @@
-motion_require 'base'
+
 
 module Formotion
   module RowType

--- a/lib/formotion/section/section.rb
+++ b/lib/formotion/section/section.rb
@@ -1,4 +1,4 @@
-motion_require "../base"
+
 
 module Formotion
   class Section < Formotion::Base


### PR DESCRIPTION
I've submitted the issue with the RubyMotion team and I'm sure they'll look into it and address it. Until then this pull request removes the use of the &/to_proc syntactic sugar as it causes a <code>malloc</code> leak in the underlying RubyMotion code.

It leaks 16 bytes each time sub_render is called. Admittedly, that isn't too much. _But_, it is still a leak.
