### PR TITLE
Remove black bar style.

### DIFF
--- a/lib/formotion/row_type/string_row.rb
+++ b/lib/formotion/row_type/string_row.rb
@@ -156,7 +156,6 @@ module Formotion
           @input_accessory ||= begin
             tool_bar = UIToolbar.alloc.initWithFrame([[0, 0], [0, 44]])
             tool_bar.autoresizingMask = UIViewAutoresizingFlexibleWidth
-            tool_bar.barStyle = UIBarStyleBlack
             tool_bar.translucent = true
 
             left_space = UIBarButtonItem.alloc.initWithBarButtonSystemItem(


### PR DESCRIPTION
I removed the setting of the bar style to black by default. I would love to add support for custom input accessories.

Something like: 

```
  else
    if input_accessory.class == UIToolbar
      input_accessory
    else
      nil
    end
end
```

thoughts?
