### PR TITLE
Fix submit row text being slightly too far left.

### DIFF
--- a/lib/formotion/row_type/button.rb
+++ b/lib/formotion/row_type/button.rb
@@ -20,8 +20,8 @@ module Formotion
               ((self.frame.size.send(dimen) - frame.size.send(dimen)) / 2.0)
             }
 
-            self.textLabel.center = CGPointMake(self.frame.size.width / 2 - (Formotion::RowType::Base.field_buffer / 2), self.textLabel.center.y)
-            self.detailTextLabel.center = CGPointMake(self.frame.size.width / 2 - (Formotion::RowType::Base.field_buffer / 2), self.detailTextLabel.center.y)
+            self.textLabel.center = CGPointMake(self.frame.size.width / 2, self.textLabel.center.y)
+            self.detailTextLabel.center = CGPointMake(self.frame.size.width / 2, self.detailTextLabel.center.y)
           end
         end
         nil


### PR DESCRIPTION
I noticed that the text on the submit button was slight left of centre.

So I removed the use of #field_buffer. I tried this on multiple devices in the simulator and all appeared to still be centred after the fix was in place.

Here is a before and after shot:

---
### Before (with #field_buffer)

![screen shot 2013-11-07 at 7 36 46 am](https://f.cloud.github.com/assets/94960/1486499/72f03580-4724-11e3-9e50-2d6cad37635f.png)
### After (without #field_buffer)

![screen shot 2013-11-07 at 7 38 41 am](https://f.cloud.github.com/assets/94960/1486500/75635e0a-4724-11e3-8052-5ddb948d9c3c.png)
