### PR TITLE
Rename :map_view to :map

### DIFF
--- a/LIST_OF_ROW_TYPES.md
+++ b/LIST_OF_ROW_TYPES.md
@@ -432,7 +432,7 @@ Use a `:display_key` to show the value of the subform in the row:
 ```ruby
 {
   title: "Map",
-  type: :map_view,
+  type: :map,
   value: coordinates,  # of type CLLocationCoordinate2D
   row_height: 200      # for better viewing
 }


### PR DESCRIPTION
Looks like this changed a while ago and the documentation was never updated: https://github.com/clayallsopp/formotion/search?q=map_view&ref=cmdform
