### PR TITLE
added input accessory view (done button) to picker row type.

### DIFF
--- a/LIST_OF_ROW_TYPES.md
+++ b/LIST_OF_ROW_TYPES.md
@@ -71,11 +71,12 @@ All character based row types accept following properties:
   type: :string,
   placeholder: 'James Bond',
   auto_correction: :no,
-  auto_capitalization: :none
+  auto_capitalization: :none,
+  input_accessory: :done
 }
 ```
 
-The `StringRow` is a simple text input row and opens a `UIKeyboardTypeDefault` keyboard when editing.
+The `StringRow` is a simple text input row and opens a `UIKeyboardTypeDefault` keyboard when editing. `input_accessory` can be nil or `:done`, and shows a toolbar with a done button above the keyboard.
 
 
 ### <a name="text"></a> Text row
@@ -356,7 +357,8 @@ The `SliderRow` takes a ruby range as `range` property that defines the min and 
   key: :pick,
   type: :picker,
   items: ["Ruby", "Motion", "Rocks"],
-  value: "Motion"
+  value: "Motion",
+  input_accessory: :done
 }
 ```
 

--- a/examples/KitchenSink/Rakefile
+++ b/examples/KitchenSink/Rakefile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
-require 'motion/project'
+require 'motion/project/template/ios'
 
-require 'rubygems'
-require 'bundler'
-Bundler.require :default
+begin
+  require 'bundler'
+  Bundler.require
+rescue LoadError
+end
 
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.

--- a/examples/KitchenSink/app/app_delegate.rb
+++ b/examples/KitchenSink/app/app_delegate.rb
@@ -16,13 +16,15 @@ class AppDelegate
           placeholder: "me@mail.com",
           type: :email,
           auto_correction: :no,
-          auto_capitalization: :none
+          auto_capitalization: :none,
+          input_accessory: :done
         }, {
           title: "Gender",
           key: :gender,
           type: :picker,
-          items: [['Female', 'f'], ['Male', 'm']],
-          value: 'm'
+          items: [['Female', 'f'],['fds', 'df'],['fddfsfds', 'f3'],['fdfafds', 'f33'], ['Male', 'm']],
+          value: 'm',
+          input_accessory: :done
         }, {
           title: "Password",
           key: :password,
@@ -35,14 +37,16 @@ class AppDelegate
           placeholder: "555-555-5555",
           type: :phone,
           auto_correction: :no,
-          auto_capitalization: :none
+          auto_capitalization: :none,
+          input_accessory: :done
         }, {
           title: "Number",
           key: :number,
           placeholder: "12345",
           type: :number,
           auto_correction: :no,
-          auto_capitalization: :none
+          auto_capitalization: :none,
+          input_accessory: :done
         }, {
           title: "Subtitle",
           subtitle: "Confirmation",

--- a/lib/formotion/row_type/picker_row.rb
+++ b/lib/formotion/row_type/picker_row.rb
@@ -8,6 +8,38 @@ module Formotion
       include RowType::ItemsMapper
       include RowType::MultiChoiceRow
 
+      def input_accessory_view(input_accessory)
+        case input_accessory
+        when :done
+          @input_accessory ||= begin
+            tool_bar = UIToolbar.alloc.initWithFrame([[0, 0], [0, 44]])
+            tool_bar.autoresizingMask = UIViewAutoresizingFlexibleWidth
+            tool_bar.translucent = true
+
+            left_space = UIBarButtonItem.alloc.initWithBarButtonSystemItem(
+                UIBarButtonSystemItemFlexibleSpace,
+                target: nil,
+                action: nil)
+
+            done_button = UIBarButtonItem.alloc.initWithBarButtonSystemItem(
+                UIBarButtonSystemItemDone,
+                target: self,
+                action: :done_editing)
+
+            tool_bar.items = [left_space, done_button]
+
+            tool_bar
+          end
+        else
+          nil
+        end
+      end
+
+      # Callback for "Done" button in input_accessory_view
+      def done_editing
+        self.row.text_field.endEditing(true)
+      end
+
       def after_build(cell)
         self.row.text_field.inputView = self.picker
         self.row.text_field.text = name_for_value(row.value).to_s


### PR DESCRIPTION
added support for `input_accessory: :done` to `Picker` rows.

also updated the kithensink example to work with rubymotion 2.17.
