### PR TITLE
Field buffer set to 20 points across all iOS7+ devices

### DIFF
--- a/lib/formotion/row_type/base.rb
+++ b/lib/formotion/row_type/base.rb
@@ -4,7 +4,7 @@ module Formotion
       attr_accessor :row, :tableView
 
       def self.field_buffer
-        if Device.iphone? or App.window.size.width <= 320
+        if Device.iphone? or App.window.size.width <= 320 or Device.ios_version >= "7.0"
           20
         else
           64


### PR DESCRIPTION
Fixes issues with right alignment of fields on iOS7 (iPad):

Before:
![screenshot 2014-02-04 09 13 18](https://f.cloud.github.com/assets/4595/2078615/4ea7e7e4-8dc0-11e3-9204-36fa9c6bf68b.png)

After:
![screenshot 2014-02-04 09 11 24](https://f.cloud.github.com/assets/4595/2078618/545a6054-8dc0-11e3-9a27-3169145b1013.png)
