### PR TITLE
Fix to map_row build_cell to return nil instead of value of swizzle which caused crash on becomeFirstResponder

### DIFF
--- a/lib/formotion/row_type/map_row.rb
+++ b/lib/formotion/row_type/map_row.rb
@@ -121,7 +121,7 @@ module Formotion
           end
         end
 
-        @map_view
+        nil
       end
 
       def on_select(tableView, tableViewDelegate)


### PR DESCRIPTION
The return value of `Formotion::RowType::MapRow#build_cell` was the value of the call to         `cell.swizzle(:layoutSubviews) do` (line 108) instead of nil. This was causing a crash with a method not found error when `becomeFirstResponder` was called during focus change. This change request ads a nil return value to stop the crash.
