### PR TITLE
Call BW::Device explicitly instead of Device

### DIFF
--- a/lib/formotion/patch/ui_text_field.rb
+++ b/lib/formotion/patch/ui_text_field.rb
@@ -115,7 +115,7 @@ class UITextField_Delegate
       return self.textFieldShouldEndEditing_callback.call(theTextField)
     end
 
-    if Device.ios_version >= "7.0"
+    if BW::Device.ios_version >= "7.0"
       theTextField.text = theTextField.text.gsub("\u00a0", " ").strip
     end
 
@@ -134,7 +134,7 @@ class UITextField_Delegate
     end
 
     # fix for UITextField in iOS7 http://stackoverflow.com/questions/19569688/uitextfield-spacebar-does-not-advance-cursor-in-ios-7/20129483#20129483
-    if Device.ios_version >= "7.0"
+    if BW::Device.ios_version >= "7.0"
       if range.location == theTextField.text.length && string == " "
         theTextField.text = theTextField.text.stringByAppendingString("\u00a0")
         return false

--- a/lib/formotion/row_type/base.rb
+++ b/lib/formotion/row_type/base.rb
@@ -4,7 +4,7 @@ module Formotion
       attr_accessor :row, :tableView
 
       def self.field_buffer
-        if Device.iphone? or App.window.size.width <= 320 or Device.ios_version >= "7.0"
+        if BW::Device.iphone? or App.window.size.width <= 320 or BW::Device.ios_version >= "7.0"
           20
         else
           64

--- a/lib/formotion/row_type/number_row.rb
+++ b/lib/formotion/row_type/number_row.rb
@@ -5,7 +5,7 @@ module Formotion
     class NumberRow < StringRow
 
       def keyboardType
-        if Device.ipad?
+        if BW::Device.ipad?
           return UIKeyboardTypeNumberPad
         end
         UIKeyboardTypeDecimalPad


### PR DESCRIPTION
Removes the assumption that Device == BW::Device to prevent errors if Device has already been defined.

I'm not sure if this is necessary. Though for my own builds, it's breaking because I already have a class Device defined. This causes Formotion to call my defined Device class rather than BW::Device.

I hope that helps.
