### PR TITLE
Adds input accessory for string and text row types. With working tests.

### DIFF
--- a/lib/formotion/row/row.rb
+++ b/lib/formotion/row/row.rb
@@ -102,6 +102,9 @@ module Formotion
       # OPTIONS: :done (a black translucent toolbar with a right-aligned "Done" button)
       # DEFAULT is nil
       :input_accessory,
+      # Call a method when the input accessory is tapped.
+      # Default is nil
+      :done_action,
       # Cell selection style
       # OPTIONS: :blue, :gray, :none
       # DEFAULT is :blue

--- a/lib/formotion/row_type/base.rb
+++ b/lib/formotion/row_type/base.rb
@@ -111,6 +111,41 @@ module Formotion
         block.call
         @semaphore = false
       end
+
+      # Creates the inputAccessoryView to show
+      # if input_accessory property is set on row.
+      # :done is currently the only supported option.
+      def input_accessory_view(input_accessory)
+        case input_accessory
+        when :done
+          @input_accessory ||= begin
+            tool_bar = UIToolbar.alloc.initWithFrame([[0, 0], [0, 44]])
+            tool_bar.autoresizingMask = UIViewAutoresizingFlexibleWidth
+            tool_bar.translucent = true
+
+            left_space = UIBarButtonItem.alloc.initWithBarButtonSystemItem(
+                UIBarButtonSystemItemFlexibleSpace,
+                target: nil,
+                action: nil)
+
+            done_button = UIBarButtonItem.alloc.initWithBarButtonSystemItem(
+                UIBarButtonSystemItemDone,
+                target: self,
+                action: :done_editing)
+
+            tool_bar.items = [left_space, done_button]
+
+            tool_bar
+          end
+        else
+          nil
+        end
+      end
+
+      def done_editing
+        NSLog "Please implement the done_editing method in your new cell type."
+      end
+
     end
   end
 end

--- a/lib/formotion/row_type/string_row.rb
+++ b/lib/formotion/row_type/string_row.rb
@@ -147,39 +147,9 @@ module Formotion
         self.row.text_field.text = row_value
       end
 
-      # Creates the inputAccessoryView to show
-      # if input_accessory property is set on row.
-      # :done is currently the only supported option.
-      def input_accessory_view(input_accessory)
-        case input_accessory
-        when :done
-          @input_accessory ||= begin
-            tool_bar = UIToolbar.alloc.initWithFrame([[0, 0], [0, 44]])
-            tool_bar.autoresizingMask = UIViewAutoresizingFlexibleWidth
-            tool_bar.translucent = true
-
-            left_space = UIBarButtonItem.alloc.initWithBarButtonSystemItem(
-                UIBarButtonSystemItemFlexibleSpace,
-                target: nil,
-                action: nil)
-
-            done_button = UIBarButtonItem.alloc.initWithBarButtonSystemItem(
-                UIBarButtonSystemItemDone,
-                target: self,
-                action: :done_editing)
-
-            tool_bar.items = [left_space, done_button]
-
-            tool_bar
-          end
-        else
-          nil
-        end
-      end
-
-      # Callback for "Done" button in input_accessory_view
       def done_editing
         self.row.text_field.endEditing(true)
+        self.row.done_action.call unless self.row.done_action.nil?
       end
 
     end

--- a/lib/formotion/row_type/text_row.rb
+++ b/lib/formotion/row_type/text_row.rb
@@ -22,6 +22,7 @@ module Formotion
         field.returnKeyType = row.return_key || UIReturnKeyDefault
         field.autocapitalizationType = row.auto_capitalization if row.auto_capitalization
         field.autocorrectionType = row.auto_correction if row.auto_correction
+        field.inputAccessoryView = input_accessory_view(row.input_accessory) if row.input_accessory
 
         # must be set prior to placeholder!
         field.font = BW::Font.new(row.font) if row.font
@@ -87,6 +88,11 @@ module Formotion
 
       def dismissKeyboard
         field.resignFirstResponder
+      end
+
+      def done_editing
+        dismissKeyboard
+        self.row.done_action.call unless self.row.done_action.nil?
       end
 
     end

--- a/spec/helpers/row_test_helpers.rb
+++ b/spec/helpers/row_test_helpers.rb
@@ -14,7 +14,12 @@ module Bacon
     def tests_row(row_settings, &block)
       if row_settings.is_a? Symbol
         type = row_settings
-        row_settings = { type: type, key: type, title: type.capitalize.to_s }
+        row_settings = {
+          type: type,
+          key: type,
+          title: type.capitalize.to_s,
+          input_accessory: :done
+        }
       end
       before do
         @row = Formotion::Row.new(row_settings)

--- a/spec/row_type/string_spec.rb
+++ b/spec/row_type/string_spec.rb
@@ -61,6 +61,15 @@ describe "String Row Type" do
     @row.text_field.keyboardType.should == UIKeyboardTypeDefault
   end
 
+  # Input Accessory
+  it "should have an input accessory" do
+    cell = @row.make_cell
+    @row.text_field.inputAccessoryView.should != nil
+  end
+
+  it "should call the done_action when hitting the 'done' button" do
+  end
+
   describe "on_select" do
 
     it "should call _on_select" do

--- a/spec/row_type/text_spec.rb
+++ b/spec/row_type/text_spec.rb
@@ -45,4 +45,13 @@ describe "Text Row" do
     @row.text_field.placeholder.should == 'placeholder'
   end
 
+  # Input Accessory
+  it "should have an input accessory" do
+    cell = @row.make_cell
+    @row.text_field.inputAccessoryView.should != nil
+  end
+
+  it "should call the done_action when hitting the 'done' button" do
+  end
+
 end


### PR DESCRIPTION
Not quite sure how to test the done_action property. This ought to do for now though.

Example usage:

``` ruby
{
  title: "Title Goes Here",
  type: :string,
  value: "Something",
  input_accessory: :done,
  done_action: -> { puts "Done Action" }
}
```

works for string rows, text rows, and all others that inherit from those :)
