### PR TITLE
ensure the UIDatePicker gets updated if we update the row value

### DIFF
--- a/lib/formotion/row_type/date_row.rb
+++ b/lib/formotion/row_type/date_row.rb
@@ -58,7 +58,6 @@ module Formotion
         #ensure the UIDatePicker gets updated if we update the row value 
         observe(self.row, "value") do |old_value, new_value|
           self.picker.setDate(date_from_numeric(new_value), animated:true)
-          row.form.reload_data
         end
 
         update


### PR DESCRIPTION
I had the issue that when observing a date_row via KVO for changes the formation table view text field in the form was updated, but not the UIDatePicker. Put in an Observer in the date_row model.
