### PR TITLE
Add in header/footer height delegate methods for Formotion::Section

### DIFF
--- a/lib/formotion/form/form_delegate.rb
+++ b/lib/formotion/form/form_delegate.rb
@@ -59,6 +59,14 @@ module Formotion
       self.sections[section].footer
     end
 
+    def tableView(tableView, heightForFooterInSection:section)
+      self.sections[section].footer_height || 0.0
+    end
+
+    def tableView(tableView, heightForHeaderInSection:section)
+      self.sections[section].header_height || 0.0
+    end
+
     def tableView(tableView, cellForRowAtIndexPath:indexPath)
       row = row_for_index_path(indexPath)
       reuseIdentifier = row.reuse_identifier

--- a/lib/formotion/section/section.rb
+++ b/lib/formotion/section/section.rb
@@ -14,7 +14,11 @@ module Formotion
       # IF :select_one is true, then @form.render will contain
       # the checked row's value as the value for this key.
       # ELSE it does nothing.
-      :key
+      :key,
+
+      # height for footer / header
+      :footer_height,
+      :header_height,
     ]
     PROPERTIES.each {|prop|
       attr_accessor prop


### PR DESCRIPTION
This is untested as of now, but I'm using it in one of my projects. Does this make sense for formotion? Since these aren't the easiest tweaks to make, it makes sense to me, especially given the :row_height attribute.
