### PR TITLE
Propose passing a block or motion-kit class on row creation

### DIFF
--- a/lib/formotion/row/row.rb
+++ b/lib/formotion/row/row.rb
@@ -117,6 +117,8 @@ module Formotion
       # DEFAULT is :blue
       :selection_style,
 
+      # Motion-Kit layout for this cell
+      :layout,
       # The following apply only to weblink rows
 
       # Whether or not to display a warning to the user before leaving the app.
@@ -168,6 +170,8 @@ module Formotion
     # Owning template row, if applicable
     attr_accessor :template_parent
     attr_accessor :template_children
+
+    # layout
 
     def initialize(params = {})
       super


### PR DESCRIPTION
This is mainly just a proposal with an example of something I'm using in a project. 

This allows me to pass a MotionKit::Layout class to the row and store it on the row, allowing me to initialize cell layouts. I don't think this makes sense for everybody, but I definitely like the idea of having a :row_callback attribute where we can pass a block to be called for each cell creation. Basically a delegate within the `def tableView(tableView, willDisplayCell: cell, forRowAtIndexPath: indexPath)` method. 

Does this make sense? I'd like to be able to manipulate cells and maybe even sections without digging through formotion internals
