### PR TITLE
Fix the crash when pressing next on the keyboard with the next element an image

### DIFF
--- a/lib/formotion/row_type/string_row.rb
+++ b/lib/formotion/row_type/string_row.rb
@@ -103,7 +103,7 @@ module Formotion
           end
         else
           field.should_return? do |text_field|
-            if row.next_row && row.next_row.text_field
+            if row.next_row && row.next_row.text_field && row.next_row.text_field != :layoutSubviews
               row.next_row.text_field.becomeFirstResponder
             else
               text_field.resignFirstResponder


### PR DESCRIPTION
Pressing next on the keyboard it will crash the app if the next field it's a photo for example.
It's strange because row.next_row.text_field it's a text_field and it returns :layoutSubviews

An example form that will crash the app
```
form = Formotion::Form.new({
      title: 'editor',
      sections: [{
        rows: [{
          title: 'Name:',
          type: :string,
          key: :name

      }, {
          title: 'Photo:',
          key: :photo,
          type: :image
        }]
      }]
    })
```

Don't know if it's the best solution to fix it, but it's working for me 😜