### PR TITLE
Because some rows are not returning nil the app is crashing on pressing next on the keyboard button

### DIFF
--- a/lib/formotion/row_type/image_row.rb
+++ b/lib/formotion/row_type/image_row.rb
@@ -52,6 +52,8 @@ module Formotion
             formotion_field.frame = field_frame
           end
         end
+
+	nil
       end
 
       def on_select(tableView, tableViewDelegate)

--- a/lib/formotion/row_type/paged_image_row.rb
+++ b/lib/formotion/row_type/paged_image_row.rb
@@ -80,6 +80,8 @@ module Formotion
             scroll_view.delegate.clearPages
           end
         end
+
+	nil
       end
 
       def on_select(tableView, tableViewDelegate)

--- a/lib/formotion/row_type/web_view_row.rb
+++ b/lib/formotion/row_type/web_view_row.rb
@@ -60,6 +60,8 @@ module Formotion
             formotion_field.frame = field_frame
           end
         end
+
+	nil
       end
 
       def on_select(tableView, tableViewDelegate)


### PR DESCRIPTION
When pressing next on the keyboard that's opened by a StringRow it's crashing if the next row is an ImageRow, WebViewRow or a PagedImageRow.
The problem is that those rows return something else than nil, for example ImageRow returns :layoutSubviews which will pass the if on https://github.com/clayallsopp/formotion/blob/master/lib/formotion/row_type/string_row.rb#L106

As from the example on https://github.com/clayallsopp/formotion/blob/master/NEW_ROW_TYPES.md#2 these rows should return nil.

Example form that will crash:
```
form = Formotion::Form.new({
      title: 'editor',
      sections: [{
        rows: [{
          title: 'Name:',
          type: :string,
          key: :name

        }, {
          title: 'Photo:',
          key: :photo,
          type: :image
        }, {
          title: 'Name:',
          type: :string,
          key: :name
        }, {
          title: 'web:',
          key: :photo,
          type: :web_view
        }, {
          title: 'Name:',
          type: :string,
          key: :name
        }, {
          title: 'paged_image:',
          key: :photo,
          type: :paged_image
        }]
      }]
    })
```

The line that's crashing:
```
2015-01-20 22:39:57.750 formotion-bug[91759:841400] *** Terminating app due to uncaught exception 'NoMethodError', reason: 'string_row.rb:107:in `block in add_callbacks:': undefined method `becomeFirstResponder' for :layoutSubviews:Symbol (NoMethodError)
```

This is a better fix than PR #238