### PR TITLE
fix image row for iPads on iOS8

### DIFF
--- a/lib/formotion/row_type/image_row.rb
+++ b/lib/formotion/row_type/image_row.rb
@@ -71,7 +71,7 @@ module Formotion
         @action_sheet.showInView @image_view
       end
 
-      def actionSheet actionSheet, clickedButtonAtIndex: index
+      def actionSheet actionSheet, didDismissWithButtonIndex: index
         source = nil
 
         if index == actionSheet.destructiveButtonIndex


### PR DESCRIPTION
There is a subtle bug that manifests itself with iOS 8 on an iPad where you cannot choose or take a picture due to UIActionSheet being deprecated. Changing the method signature fixes it.

reference to solution: http://stackoverflow.com/a/26393532/135410