### PR TITLE
Ignore nil slider values, use row's min instead.

### DIFF
--- a/lib/formotion/row_type/slider_row.rb
+++ b/lib/formotion/row_type/slider_row.rb
@@ -26,7 +26,7 @@ module Formotion
         end
         observe(self.row, "value") do |old_value, new_value|
           break_with_semaphore do
-            slideView.setValue(row.value, animated:false)
+            slideView.setValue(row.value || self.row.range.min, animated:false)
           end
         end
 

--- a/spec/row_type/slider_spec.rb
+++ b/spec/row_type/slider_spec.rb
@@ -29,6 +29,15 @@ describe "Slider Row" do
     cell.accessoryView.value.should == 75
   end
 
+  it "should use the range's min in the absence of a value" do
+    @row.range = (1..10)
+    @row.value = 4
+    cell = @row.make_cell
+
+    @row.value = nil
+    cell.accessoryView.value.should == 1
+  end
+
   # Range
   it "should use default range" do
     @row.range = nil


### PR DESCRIPTION
Attempting to set a UISlider's value to nil (done when calling
form.reset) causes the following exception:

TypeError: can't convert nil into Float

Instead, ignore nil values and use the row's range.min as a fallback.