### PR TITLE
Set value when didSelectRow called in picker_row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.8.1 - September 14, 2016
+
+### Bug Fixes
+
+- Fixed a bug in `picker_row` where the value of picker wasn't being set in `didSelectRow`.
+
 ## 1.3.1 - April 15, 2013
 
 ### Features

--- a/lib/formotion/row_type/picker_row.rb
+++ b/lib/formotion/row_type/picker_row.rb
@@ -43,6 +43,7 @@ module Formotion
 
       def pickerView(pickerView, didSelectRow:index, inComponent:component)
         update_text_field(value_for_name_index(index))
+        on_change(self.row.text_field)
       end
 
       def on_change(text_field)


### PR DESCRIPTION
Fixes #247 

`on_change` isn't called in `picker_row` because it doesn't implement UITextField.