### PR TITLE
Remove motion require

### DIFF
--- a/Formotion.gemspec
+++ b/Formotion.gemspec
@@ -16,6 +16,5 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency "bubble-wrap", ">= 1.4.0"
-  s.add_dependency "motion-require", ">= 0.1.0"
   s.add_development_dependency 'rake'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'guard-motion'
+gem 'guard-motion', github: 'satoyos/guard-motion', branch: 'inherit_Plugin'
 gem 'rb-fsevent'
 
 gem "motion-cocoapods"

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios'
 require "bundler/gem_tasks"
 require "bundler/setup"

--- a/lib/formotion.rb
+++ b/lib/formotion.rb
@@ -3,9 +3,7 @@ require 'bubble-wrap/core'
 require 'bubble-wrap/font'
 require 'bubble-wrap/camera'
 
-require 'motion-require'
 
-Motion::Require.all(Dir.glob(File.expand_path('../formotion/**/*.rb', __FILE__)))
 
 Motion::Project::App.setup do |app|
   app.frameworks<<'CoreLocation' unless app.frameworks.include?('CoreLocation')

--- a/lib/formotion.rb
+++ b/lib/formotion.rb
@@ -3,11 +3,16 @@ require 'bubble-wrap/core'
 require 'bubble-wrap/font'
 require 'bubble-wrap/camera'
 
-
-
 Motion::Project::App.setup do |app|
-  app.frameworks<<'CoreLocation' unless app.frameworks.include?('CoreLocation')
-  app.frameworks<<'MapKit' unless app.frameworks.include?('MapKit')
-  
+  core_lib = File.join(File.dirname(__FILE__), 'formotion')
+  insert_point = app.files.find_index { |file| file =~ /^(?:\.\/)?app\// } || 0
+
+  Dir.glob(File.join(core_lib, '**/*.rb')).reverse.each do |file|
+    app.files.insert(insert_point, file)
+  end
+
+  app.frameworks << 'CoreLocation' unless app.frameworks.include?('CoreLocation')
+  app.frameworks << 'MapKit' unless app.frameworks.include?('MapKit')
+
   app.resources_dirs << File.join(File.dirname(__FILE__), '../resources')
 end

--- a/lib/formotion/base.rb
+++ b/lib/formotion/base.rb
@@ -1,5 +1,3 @@
-motion_require 'row_type/base'
-
 module Formotion
   class Base
     def initialize(params = {})

--- a/lib/formotion/controller/form_controller.rb
+++ b/lib/formotion/controller/form_controller.rb
@@ -1,5 +1,3 @@
-motion_require '../patch/ui_text_field'
-
 #################
 #
 # Formotion::FormController

--- a/lib/formotion/form/form.rb
+++ b/lib/formotion/form/form.rb
@@ -1,5 +1,3 @@
-motion_require "../base"
-
 module Formotion
   class Form < Formotion::Base
     extend BubbleWrap::KVO

--- a/lib/formotion/form/form_delegate.rb
+++ b/lib/formotion/form/form_delegate.rb
@@ -1,5 +1,3 @@
-motion_require "../base"
-
 module Formotion
   class Form < Formotion::Base
     attr_reader :table

--- a/lib/formotion/row/row.rb
+++ b/lib/formotion/row/row.rb
@@ -1,5 +1,3 @@
-motion_require "../base"
-
 module Formotion
   class Row < Formotion::Base
     PROPERTIES = [

--- a/lib/formotion/row_type/activity_view_row.rb
+++ b/lib/formotion/row_type/activity_view_row.rb
@@ -1,5 +1,3 @@
-motion_require 'object_row'
-
 module Formotion
   module RowType
     class ActivityRow < ObjectRow

--- a/lib/formotion/row_type/back_row.rb
+++ b/lib/formotion/row_type/back_row.rb
@@ -1,5 +1,3 @@
-motion_require 'button'
-
 module Formotion
   module RowType
     class BackRow < ButtonRow

--- a/lib/formotion/row_type/button.rb
+++ b/lib/formotion/row_type/button.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 module Formotion
   module RowType
     class ButtonRow < Base

--- a/lib/formotion/row_type/check_row.rb
+++ b/lib/formotion/row_type/check_row.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 module Formotion
   module RowType
     class CheckRow < Base

--- a/lib/formotion/row_type/currency_row.rb
+++ b/lib/formotion/row_type/currency_row.rb
@@ -1,5 +1,3 @@
-motion_require 'number_row'
-
 module Formotion
   module RowType
     class CurrencyRow < NumberRow

--- a/lib/formotion/row_type/date_row.rb
+++ b/lib/formotion/row_type/date_row.rb
@@ -1,6 +1,3 @@
-motion_require 'string_row'
-motion_require 'multi_choice_row'
-
 module Formotion
   module RowType
     class DateRow < StringRow
@@ -54,8 +51,8 @@ module Formotion
           self.picker.setDate(self.picker.date, animated:true)
           picker.countDownDuration = self.row.value.to_f
         end
-        
-        #ensure the UIDatePicker gets updated if we update the row value 
+
+        #ensure the UIDatePicker gets updated if we update the row value
         observe(self.row, "value") do |old_value, new_value|
           self.picker.setDate(date_from_numeric(new_value), animated:true)
         end

--- a/lib/formotion/row_type/edit_row.rb
+++ b/lib/formotion/row_type/edit_row.rb
@@ -1,5 +1,3 @@
-motion_require 'button'
-
 module Formotion
   module RowType
     class EditRow < ButtonRow

--- a/lib/formotion/row_type/email_row.rb
+++ b/lib/formotion/row_type/email_row.rb
@@ -1,5 +1,3 @@
-motion_require 'string_row'
-
 module Formotion
   module RowType
     class EmailRow < StringRow

--- a/lib/formotion/row_type/image_row.rb
+++ b/lib/formotion/row_type/image_row.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 module Formotion
   module RowType
     class ImageRow < Base

--- a/lib/formotion/row_type/map_row.rb
+++ b/lib/formotion/row_type/map_row.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 module Formotion
   module RowType
     class MapRowData

--- a/lib/formotion/row_type/number_row.rb
+++ b/lib/formotion/row_type/number_row.rb
@@ -1,5 +1,3 @@
-motion_require 'string_row'
-
 module Formotion
   module RowType
     class NumberRow < StringRow

--- a/lib/formotion/row_type/object_row.rb
+++ b/lib/formotion/row_type/object_row.rb
@@ -1,5 +1,3 @@
-motion_require 'string_row'
-
 module Formotion
   module RowType
     class ObjectRow < StringRow

--- a/lib/formotion/row_type/options_row.rb
+++ b/lib/formotion/row_type/options_row.rb
@@ -1,6 +1,3 @@
-motion_require 'base'
-motion_require 'items_mapper'
-
 module Formotion
   module RowType
     class OptionsRow < Base

--- a/lib/formotion/row_type/paged_image_row.rb
+++ b/lib/formotion/row_type/paged_image_row.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 # ideas taken from:
 # http://www.raywenderlich.com/10518/how-to-use-uiscrollview-to-scroll-and-zoom-content
 
@@ -19,9 +17,9 @@ module Formotion
       def build_cell(cell)
         # only show the "plus" when editable
         add_plus_accessory(cell) if row.editable?
-        
+
         self.row.value = [] unless self.row.value.is_a?(Array)
-        
+
         @page_view     = UIPageControl.alloc.init
         @page_view.tag = PAGE_VIEW_TAG
         @page_view.pageIndicatorTintColor        = '#d0d0d0'.to_color
@@ -37,7 +35,7 @@ module Formotion
           @scroll_view.contentOffset=point
         end
         cell.addSubview(@page_view)
-        
+
         @scroll_view          = UIScrollView.alloc.init
         @scroll_view.tag      = SCROLL_VIEW_TAG
         @scroll_view.delegate = self
@@ -45,7 +43,7 @@ module Formotion
         @scroll_view.delaysContentTouches = true
         @scroll_view.showsHorizontalScrollIndicator=false
         @scroll_view.showsVerticalScrollIndicator=false
-        
+
         pages_size = @scroll_view.frame.size
         @scroll_view.contentSize = CGSizeMake(pages_size.width * self.row.value.size, pages_size.height)
         @page_views = [nil]*self.row.value.size
@@ -57,7 +55,7 @@ module Formotion
             old_layoutSubviews
 
             # viewWithTag is terrible, but I think it's ok to use here...
-            
+
             formotion_field = self.viewWithTag(SCROLL_VIEW_TAG)
             field_frame = formotion_field.frame
             field_frame.origin.y = 10
@@ -67,7 +65,7 @@ module Formotion
             field_frame.size.height = f_height
             formotion_field.frame = field_frame
             scroll_view=formotion_field
-            
+
             formotion_field = self.viewWithTag(PAGE_VIEW_TAG)
             field_frame = formotion_field.frame
             field_frame.origin.y = 20 + f_height
@@ -75,7 +73,7 @@ module Formotion
             field_frame.size.width  = self.frame.size.width - field_frame.origin.x - Formotion::RowType::Base.field_buffer
             field_frame.size.height = 10
             formotion_field.frame = field_frame
-            
+
             scroll_view.delegate.resizePages
             scroll_view.delegate.clearPages
           end
@@ -98,7 +96,7 @@ module Formotion
           self.clearPages
           return
         end
-    
+
         source = nil
         case actionSheet.buttonTitleAtIndex(index)
         when TAKE
@@ -141,7 +139,7 @@ module Formotion
         end
         cell.accessoryView = cell.editingAccessoryView = @add_button
       end
-      
+
       #{{{Paged
       def loadVisiblePages
         # First, determine which page is currently visible
@@ -163,12 +161,12 @@ module Formotion
           self.purgePage(i)
         end
       end
-      
+
       def get_active_page
         page_width = @scroll_view.frame.size.width
         ((@scroll_view.contentOffset.x * 2.0 + page_width) / (page_width * 2.0)).floor
       end
-  
+
       def pages_single_tap
         page = get_active_page
         if row.editable?
@@ -177,7 +175,7 @@ module Formotion
           _on_select(nil, nil)
         end
       end
-  
+
       def take_photo(_page=nil)
         @photo_page=_page
         @action_sheet = UIActionSheet.alloc.init
@@ -188,14 +186,14 @@ module Formotion
         @action_sheet.cancelButtonIndex = (@action_sheet.addButtonWithTitle CANCEL)
         @action_sheet.showInView @scroll_view
       end
-  
+
       def clearPages
         0.upto(@page_views.size-1) do |i|
           self.purgePage(i) unless @page_views[i].nil?
         end
         self.loadVisiblePages
       end
-  
+
       def resizePages
         pages_size = @scroll_view.frame.size
         @scroll_view.contentSize = CGSizeMake(pages_size.width * self.row.value.size, pages_size.height)
@@ -208,7 +206,7 @@ module Formotion
         @page_view.currentPage   = 0
         @page_view.numberOfPages = self.row.value.size
       end
-  
+
       def loadPage(_page)
         if _page < 0 || _page >= self.row.value.size
           # If it's outside the range of what we have to display, then do nothing
@@ -248,13 +246,13 @@ module Formotion
           @page_views[_page]=nil
         end
       end
-  
+
       def scrollViewDidScroll(_scroll_view)
         # Load the pages which are now on screen
         self.loadVisiblePages
       end
       #}}}
-      
+
     end
   end
 end

--- a/lib/formotion/row_type/phone_row.rb
+++ b/lib/formotion/row_type/phone_row.rb
@@ -1,5 +1,3 @@
-motion_require 'string_row'
-
 module Formotion
   module RowType
     class PhoneRow < StringRow

--- a/lib/formotion/row_type/picker_row.rb
+++ b/lib/formotion/row_type/picker_row.rb
@@ -1,6 +1,4 @@
 # currently supports only one component
-motion_require 'string_row'
-motion_require 'multi_choice_row'
 
 module Formotion
   module RowType

--- a/lib/formotion/row_type/slider_row.rb
+++ b/lib/formotion/row_type/slider_row.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 module Formotion
   module RowType
     class SliderRow < Base

--- a/lib/formotion/row_type/static_row.rb
+++ b/lib/formotion/row_type/static_row.rb
@@ -1,5 +1,3 @@
-motion_require 'string_row'
-
 module Formotion
   module RowType
     class StaticRow < StringRow

--- a/lib/formotion/row_type/string_row.rb
+++ b/lib/formotion/row_type/string_row.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 module Formotion
   module RowType
     class StringRow < Base

--- a/lib/formotion/row_type/subform_row.rb
+++ b/lib/formotion/row_type/subform_row.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 module Formotion
   module RowType
     class SubformRow < Base

--- a/lib/formotion/row_type/submit_row.rb
+++ b/lib/formotion/row_type/submit_row.rb
@@ -1,5 +1,3 @@
-motion_require 'button'
-
 module Formotion
   module RowType
     class SubmitRow < ButtonRow

--- a/lib/formotion/row_type/switch_row.rb
+++ b/lib/formotion/row_type/switch_row.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 module Formotion
   module RowType
     class SwitchRow < Base

--- a/lib/formotion/row_type/tags_row.rb
+++ b/lib/formotion/row_type/tags_row.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 # ideas and images taken from:
 # https://github.com/davbeck/TURecipientBar
 # License: https://github.com/davbeck/TURecipientBar/blob/master/LICENSE.md
@@ -15,9 +13,9 @@ module Formotion
       def build_cell(cell)
         # only show the "plus" when editable
         add_plus_accessory(cell) if row.editable?
-        
+
         self.row.value = [] unless self.row.value.is_a?(Array)
-        
+
         @scroll_view          = UIScrollView.alloc.init
         @scroll_view.tag      = row.editable? ? TAGS_EDIT_VIEW_TAG : TAGS_VIEW_TAG
         @scroll_view.delegate = self
@@ -27,7 +25,7 @@ module Formotion
         @scroll_view.showsVerticalScrollIndicator   = false
         @btns = {}
         cell.addSubview(@scroll_view)
-        
+
         row.value.each do |t|
           add_tag(t)
         end
@@ -45,11 +43,11 @@ module Formotion
               formotion_field = self.viewWithTag(TAGS_EDIT_VIEW_TAG)
             end
             field_frame = formotion_field.frame
-    
+
             field_frame.origin.x = self.textLabel.frame.origin.x + self.textLabel.frame.size.width + Formotion::RowType::Base.field_buffer
             edit_buffer = edittable ? 20.0 : 0.0
             field_frame.size.width  = self.frame.size.width - field_frame.origin.x - Formotion::RowType::Base.field_buffer - edit_buffer
-            
+
             # rearrange the tags
             last = CGRectMake(0.0, 0.0, 0.0, 0.0)
             formotion_field.subviews.each do |sv|
@@ -63,19 +61,19 @@ module Formotion
               sv.frame = now
               last = now
             end
-            
+
             # set the height of the scroll box
             max_height = self.frame.size.height - 3.0
             field_frame.size.height = last.origin.y + last.size.height + 5.0
             field_frame.size.height = max_height if field_frame.size.height > max_height
             field_frame.origin.y = (self.frame.size.height - field_frame.size.height) / 2.0
-            
+
             formotion_field.frame = field_frame
-            
+
           end
         end
       end
-      
+
       def _on_select(tableView, tableViewDelegate)
       end
 
@@ -92,32 +90,32 @@ module Formotion
         end
         cell.accessoryView = cell.editingAccessoryView = @add_button
       end
-      
+
       def image_for_state(state)
         case state
         when UIControlStateNormal
           return UIImage.imageNamed("tags_row.png").stretchableImageWithLeftCapWidth(14, topCapHeight:0)
-          
+
         when UIControlStateHighlighted, UIControlStateSelected
           return UIImage.imageNamed("tags_row-selected.png").stretchableImageWithLeftCapWidth(14, topCapHeight:0)
-                    
+
         end
         nil
       end
-      
+
       def attrib_for_state(state)
         case state
         when UIControlStateNormal
           return { NSFontAttributeName => UIFont.systemFontOfSize(14.0),
                    NSForegroundColorAttributeName => UIColor.blackColor }
-          
+
         when UIControlStateHighlighted, UIControlStateSelected
           return { NSFontAttributeName => UIFont.systemFontOfSize(14.0),
                    NSForegroundColorAttributeName => UIColor.whiteColor }
-                   
+
         end
       end
-      
+
       def add_tag(text)
         return if @btns.has_key?(text)
       	btn = UIButton.buttonWithType(UIButtonTypeCustom)
@@ -128,14 +126,14 @@ module Formotion
         btn.frame = CGRectMake(0.0, 0.0, width, 24.0)
         [UIControlStateNormal, UIControlStateHighlighted, UIControlStateSelected].each do |state|
       	  btn.setBackgroundImage(image_for_state(state), forState:state)
-          attr_text = NSAttributedString.alloc.initWithString(text, attributes:attrib_for_state(state))          
+          attr_text = NSAttributedString.alloc.initWithString(text, attributes:attrib_for_state(state))
           btn.setAttributedTitle(attr_text, forState:state)
         end
 
         if row.editable?
           btn.addTarget(self, action:'button_click:', forControlEvents:UIControlEventTouchUpInside)
         end
-    
+
       	btn.translatesAutoresizingMaskIntoConstraints = false
       	@scroll_view.addSubview(btn)
         unless row.value.include?(text)
@@ -143,7 +141,7 @@ module Formotion
         end
         @btns[text] = btn
       end
-    
+
       def button_click(btn)
         @del_btn = btn
         App.alert(BW.localized_string("Remove Tag?"), cancel_button_title: NO) do |alert|
@@ -151,7 +149,7 @@ module Formotion
           alert.delegate = self
         end
       end
-      
+
       YES = BW.localized_string("Yes", nil)
       NO = BW.localized_string("No", nil)
 
@@ -159,15 +157,15 @@ module Formotion
         if alert_view.buttonTitleAtIndex(button_index)==NO
           @del_btn = nil
           return
-        end 
+        end
         @del_btn.removeFromSuperview
         @btns.delete(@del_btn)
         row.value.delete(@del_btn.currentAttributedTitle.string)
       end
-  
+
       def scrollViewDidScroll(_scroll_view)
       end
-      
+
     end
   end
 end

--- a/lib/formotion/row_type/template_row.rb
+++ b/lib/formotion/row_type/template_row.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 # Define template row:
 # {
 #   title: "Add nickname",
@@ -60,7 +58,7 @@ module Formotion
             row.template_parent.template_children.delete_at(row.index)
           end
         end
-        
+
         # inherit some infos to template child
         if row.on_tap_callback
           new_row.on_tap_callback = row.on_tap_callback
@@ -69,7 +67,7 @@ module Formotion
           new_row.on_delete_callback = row.on_delete_callback
         end
         new_row.key = "#{row.key}_template".to_sym
-        
+
         new_row.remove_on_delete = true
         new_row.template_parent = row
         row.template_children ||= []

--- a/lib/formotion/row_type/text_row.rb
+++ b/lib/formotion/row_type/text_row.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 module Formotion
   module RowType
     class TextRow < Base

--- a/lib/formotion/row_type/web_link_row.rb
+++ b/lib/formotion/row_type/web_link_row.rb
@@ -1,5 +1,3 @@
-motion_require 'object_row'
-
 module Formotion
   module RowType
     class WebLinkRow < ObjectRow

--- a/lib/formotion/row_type/web_view_row.rb
+++ b/lib/formotion/row_type/web_view_row.rb
@@ -1,5 +1,3 @@
-motion_require 'base'
-
 module Formotion
   module RowType
     class WebViewRow < Base
@@ -17,29 +15,29 @@ module Formotion
           @loading = false
         end
       end
-      
+
       def stringByEvaluatingJavaScriptFromString(script)
         @web_view.stringByEvaluatingJavaScriptFromString(script)
       end
-      
+
       def loading
         @loading
       end
 
       def build_cell(cell)
         cell.selectionStyle = self.row.selection_style || UITableViewCellSelectionStyleBlue
-        
+
         @loading = true
         @web_view = UIWebView.alloc.init
         @web_view.delegate = self
         set_page
-        
+
         observe(self.row, "value") do |old_value, new_value|
           break_with_semaphore do
             set_page
           end
         end
-        
+
         @web_view.tag = WEB_VIEW_TAG
         @web_view.contentMode = UIViewContentModeScaleAspectFit
         @web_view.backgroundColor = UIColor.clearColor
@@ -69,7 +67,7 @@ module Formotion
           return
         end
       end
-      
+
       #def webView(web_view, didFailLoadWithError:error)
       #end
 
@@ -79,7 +77,7 @@ module Formotion
       def webViewDidFinishLoad(web_view)
         @loading = false
       end
-      
+
     end
   end
 end

--- a/lib/formotion/section/section.rb
+++ b/lib/formotion/section/section.rb
@@ -1,5 +1,3 @@
-motion_require "../base"
-
 module Formotion
   class Section < Formotion::Base
     PROPERTIES = [


### PR DESCRIPTION
This PR completely removes `motion-require`. It's no longer needed for the newest versions of RubyMotion. 

I don't expect this to get merged because this repo is a total 👻 town, but I figured I'd send the PR anyways so anyone having the same issues I was when trying to update an app that was a few years old. 

If you're having problems with this library while updating your app, use this in your gemfile:

`gem 'formotion', github: 'markrickert/formotion', branch: 'remove-motion-require'`

...unless this gets merged and a new version is released 😉 

Fixes #250 